### PR TITLE
changed resolution from 25 to 30 in Crazy Tale first paragraph

### DIFF
--- a/pygis/docs/d_raster_crs_intro.md
+++ b/pygis/docs/d_raster_crs_intro.md
@@ -143,7 +143,7 @@ All this info is stored in `dst` and then written to disk with `dst.write(Z,1)`.
 
 
 ### The Crazy Tale of the Upper Left Hand Corner
-To help us understand what is going on with `transform` it helps to work an example. For our example above we need to define the translate matrix that helps define the upper left hand corner of our rainfall raster data `Z`. In particular we need the upper left cell center to be located at (-90,90), so the upper left hand corner need to be 1/2 the resolution above and to the left of (-90,90), implying a location of (-105,105) since the resolution is 25 degrees.
+To help us understand what is going on with `transform` it helps to work an example. For our example above we need to define the translate matrix that helps define the upper left hand corner of our rainfall raster data `Z`. In particular we need the upper left cell center to be located at (-90,90), so the upper left hand corner need to be 1/2 the resolution above and to the left of (-90,90), implying a location of (-105,105) since the resolution is 30 degrees.
 
 We can visualize what we need to do here: 
 


### PR DESCRIPTION
Really great book! I'm newish to the Python geo space and your book is a terrific learning resource.

I think there's a typo in d_raster_crs_intro.md at the end of the first paragraph in the Crazy Tale ... section. Shouldn't that 25 in the last sentence be 30? I made the change in my branch.

Also, it seems like in Fig 30 and in the How Transforms Work just below, that the order of the matrix mult should be switched - there's a 3x1 pre-multiplying a 3x3. I didn't do anything about these.

