### PR TITLE
Replaced deprecated geometries module with the features module

### DIFF
--- a/pygis/docs/d_access_osm.md
+++ b/pygis/docs/d_access_osm.md
@@ -84,16 +84,16 @@ area.plot()
 ```
 ### OSM Building footprints
 
-It is also possible to retrieve other types of OSM data features with OSMnx such as buildings or points of interest (POIs). Let's download the buildings with `ox.geometries_from_place` [docs](https://osmnx.readthedocs.io/en/stable/osmnx.html?highlight=geometries_from_place#osmnx.geometries.geometries_from_place) function and plot them on top of our street network in Kamppi. 
+It is also possible to retrieve other types of OSM data features with OSMnx such as buildings or points of interest (POIs). Let's download the buildings with `ox.features_from_place` [docs](https://osmnx.readthedocs.io/en/stable/user-reference.html#osmnx.features.features_from_place) function and plot them on top of our street network in Kamppi. 
 
 
-When fetching spesific types of geometries from OpenStreetMap using OSMnx `geometries_from_place` we also need to specify the correct tags. For getting [all types of buildings](https://wiki.openstreetmap.org/wiki/Buildings), we can use the tag `building=yes`.
+When fetching spesific types of features from OpenStreetMap using OSMnx `features_from_place` we also need to specify the correct tags. For getting [all types of buildings](https://wiki.openstreetmap.org/wiki/Buildings), we can use the tag `building=yes`.
 
 ```{code-cell} ipython3
 # List key-value pairs for tags
 tags = {'building': True}   
 
-buildings = ox.geometries_from_place(place_name, tags)
+buildings = ox.features_from_place(place_name, tags)
 buildings.head()
 ```
 We can plot the footprints quickly.


### PR DESCRIPTION
The geometries module has been deprecated: https://osmnx.readthedocs.io/en/stable/user-reference.html#osmnx.geometries.geometries_from_place

Running the current code snippet using the geometries module prints the following text in the console:

UserWarning: The `geometries` module and `geometries_from_X` functions have been renamed the `features` module and `features_from_X` functions. Use these instead. The `geometries` module and function names are deprecated and will be removed in a future release.
  buildings = ox.geometries_from_place(place_name, tags)