### PR TITLE
fix link to EPSG dataset

### DIFF
--- a/pygis/docs/d_understand_crs_codes.md
+++ b/pygis/docs/d_understand_crs_codes.md
@@ -337,7 +337,7 @@ Source: [Universal Transverse Mercator, Esri](https://desktop.arcgis.com/en/arcm
 
 ## EPSG Codes
 
-Many CRSs are assigned and can be referenced by an `EPSG` code, which consists of a four or five digit number. `EPSG` stands for the European Petroleum Survey Group, a now-defunct organization that compiled this CRS dataset. `EPSG` codes can be further explored with the [EPSG Geodetic Parameter Dataset](http://www.epsg-registry.org/) or at [SpatialReference.org](https://spatialreference.org/ref/epsg/).
+Many CRSs are assigned and can be referenced by an `EPSG` code, which consists of a four or five digit number. `EPSG` stands for the European Petroleum Survey Group, a now-defunct organization that compiled this CRS dataset. `EPSG` codes can be further explored with the [EPSG Geodetic Parameter Dataset](https://epsg.org/) or at [SpatialReference.org](https://spatialreference.org/ref/epsg/).
 
 Sources:
 [Overview of Coordinate Reference Systems (CRS) in R, University of California, Santa Barbara](https://www.nceas.ucsb.edu/sites/default/files/2020-04/OverviewCoordinateReferenceSystems.pdf); [Lesson 4. Understand EPSG, WKT and Other CRS Definition Styles, Leah Wasser](https://www.earthdatascience.org/courses/use-data-open-source-python/intro-vector-data-python/spatial-data-vector-shapefiles/epsg-proj4-coordinate-reference-system-formats-python/)


### PR DESCRIPTION
this fixes a 404 link in the documentation

- [epsg-registry.org](http://www.epsg-registry.org/) is showing a 404/seems down right now
- the Internet Archive confirms this has been the case [for more than 1-2 years](https://web.archive.org/web/20230214180902/http://www.epsg-registry.org/)
- the International Association of Oil & Gas Producers talk about upgrading epsg-registry.org in favor of epsg.org [in this article](https://www.iogp.org/blog/epsg/upgrade-of-epsg-dataset-data-model/)